### PR TITLE
Extract svg background to new component

### DIFF
--- a/src/components/BackgroundPattern.tsx
+++ b/src/components/BackgroundPattern.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const BackgroundPattern: React.FC = () => {
+  return (
+    <div className="absolute inset-0 opacity-10">
+      <div 
+        className="absolute inset-0"
+        style={{
+          backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.1'%3E%3Ccircle cx='7' cy='7' r='7'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`
+        }}
+      ></div>
+    </div>
+  );
+};
+
+export default BackgroundPattern;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useAppStore } from '../store/useAppStore';
 import SearchBar from '../components/SearchBar';
 import ApartmentCard from '../components/ApartmentCard';
+import BackgroundPattern from '../components/BackgroundPattern';
 
 const HomePage = () => {
   const { 
@@ -29,9 +30,7 @@ const HomePage = () => {
       {/* Hero Section */}
       <section className="relative h-screen flex items-center justify-center gradient-primary overflow-hidden">
         {/* Background Pattern */}
-        <div className="absolute inset-0 opacity-10">
-          <div className="absolute inset-0 bg-[url('data:image/svg+xml,%3Csvg width="60" height="60" viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg"%3E%3Cg fill="none" fill-rule="evenodd"%3E%3Cg fill="%23ffffff" fill-opacity="0.1"%3E%3Ccircle cx="7" cy="7" r="7"/%3E%3C/g%3E%3C/g%3E%3C/svg%3E')]"></div>
-        </div>
+        <BackgroundPattern />
 
         <div className="container mx-auto px-4 text-center text-white relative z-10">
           <h1 className="heading-xl mb-6">


### PR DESCRIPTION
Extract SVG background pattern to a new component to fix syntax errors caused by nested quotes in the data URL.

The original inline SVG data URL within a Tailwind `bg-[url(...)]` class caused a syntax error due to conflicting double quotes. This PR resolves the issue by moving the SVG to a dedicated `BackgroundPattern` component and using a `style` prop with a template literal, allowing for proper escaping of the SVG's internal quotes.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6de4594-f71d-41ec-b6aa-85008819a460">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e6de4594-f71d-41ec-b6aa-85008819a460">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>