### PR TITLE
Make apartment listings clickable for details and location

### DIFF
--- a/src/components/ApartmentCard.tsx
+++ b/src/components/ApartmentCard.tsx
@@ -1,4 +1,4 @@
-import {Link} from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import type {Apartment} from '../store/useAppStore';
 
 interface ApartmentCardProps {
@@ -7,12 +7,26 @@ interface ApartmentCardProps {
 }
 
 const ApartmentCard = ({apartment, onBookingClick}: ApartmentCardProps) => {
+  const navigate = useNavigate();
   const formatPrice = (price: number) => {
     return new Intl.NumberFormat('ru-RU').format(price);
   };
 
+  // Handler for card click
+  const handleCardClick = () => {
+    navigate(`/apartment/${apartment.id}`);
+  };
+
+  // Prevent event bubbling from buttons
+  const stopPropagation = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
   return (
-    <div className="card card-hover">
+    <div
+      className="card card-hover cursor-pointer hover:shadow-lg transition-shadow duration-200"
+      onClick={handleCardClick}
+    >
       {/* Image */}
       <div className="relative h-48 overflow-hidden">
         <img
@@ -40,6 +54,7 @@ const ApartmentCard = ({apartment, onBookingClick}: ApartmentCardProps) => {
         <Link
           to={`/complex/${encodeURIComponent(apartment.complex)}`}
           className="text-sm text-blue-600 hover:text-blue-700 font-medium mb-1 block"
+          onClick={stopPropagation}
         >
           {apartment.complex}
         </Link>
@@ -141,13 +156,14 @@ const ApartmentCard = ({apartment, onBookingClick}: ApartmentCardProps) => {
           <Link
             to={`/apartment/${apartment.id}`}
             className="flex-1 bg-gray-100 hover:bg-gray-200 text-gray-800 py-2 px-4 rounded-lg text-center font-medium transition-colors text-sm"
+            onClick={stopPropagation}
           >
             Подробнее
           </Link>
 
           {onBookingClick && (
             <button
-              onClick={onBookingClick}
+              onClick={e => { stopPropagation(e); onBookingClick(); }}
               className="flex-1 bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded-lg font-medium transition-colors text-sm"
             >
               Записаться

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -19,7 +19,7 @@ const SearchBar = () => {
     }
   };
 
-  const handleFilterChange = (key: string, value: any) => {
+  const handleFilterChange = (key: string, value: unknown) => {
     setSearchFilters({ [key]: value });
   };
 

--- a/src/pages/ApartmentPage.tsx
+++ b/src/pages/ApartmentPage.tsx
@@ -225,6 +225,7 @@ const ApartmentPage = () => {
                       {apartment.complex}
                     </Link>
                   </div>
+                  {/* Address */}
                   <div className="flex justify-between py-3 border-b border-gray-200">
                     <span className="text-gray-600">Адрес:</span>
                     <span className="font-medium">{apartment.address}</span>
@@ -274,6 +275,70 @@ const ApartmentPage = () => {
                     </svg>
                     Индивидуальное отопление
                   </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Location Section */}
+            <div className="mt-8">
+              <h3 className="text-2xl font-bold text-gray-900 mb-6">Расположение и транспорт</h3>
+              <div className="bg-gray-100 rounded-xl p-8 text-center mb-8">
+                <div className="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                  <svg className="w-8 h-8 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                  </svg>
+                </div>
+                <h4 className="text-lg font-semibold text-gray-900 mb-2">Интерактивная карта</h4>
+                <p className="text-gray-600 mb-4">Здесь будет отображена карта с расположением квартиры</p>
+                <p className="text-sm text-gray-500">📍 {apartment.address}</p>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                <div>
+                  <h4 className="text-lg font-semibold text-gray-900 mb-4">Транспортная доступность</h4>
+                  <ul className="space-y-3 text-gray-600">
+                    <li className="flex items-center">
+                      <svg className="w-5 h-5 text-blue-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+                      </svg>
+                      Метро "Примерная" - 5 мин пешком
+                    </li>
+                    <li className="flex items-center">
+                      <svg className="w-5 h-5 text-green-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                      </svg>
+                      Автобусная остановка - 2 мин пешком
+                    </li>
+                    <li className="flex items-center">
+                      <svg className="w-5 h-5 text-purple-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" />
+                      </svg>
+                      До центра города - 15 мин на транспорте
+                    </li>
+                  </ul>
+                </div>
+                <div>
+                  <h4 className="text-lg font-semibold text-gray-900 mb-4">Инфраструктура района</h4>
+                  <ul className="space-y-3 text-gray-600">
+                    <li className="flex items-center">
+                      <svg className="w-5 h-5 text-red-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+                      </svg>
+                      Школы и детские сады поблизости
+                    </li>
+                    <li className="flex items-center">
+                      <svg className="w-5 h-5 text-green-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
+                      </svg>
+                      Торговые центры и магазины
+                    </li>
+                    <li className="flex items-center">
+                      <svg className="w-5 h-5 text-yellow-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 1.343-3 3s1.343 3 3 3 3-1.343 3-3-1.343-3-3-3zm0 0V4m0 8v8" />
+                      </svg>
+                      Парки и зоны отдыха
+                    </li>
+                  </ul>
                 </div>
               </div>
             </div>

--- a/src/pages/ApartmentsPage.tsx
+++ b/src/pages/ApartmentsPage.tsx
@@ -3,6 +3,8 @@ import { Link, useSearchParams } from 'react-router-dom';
 import { useAppStore } from '../store/useAppStore';
 import ApartmentCard from '../components/ApartmentCard';
 import SearchBar from '../components/SearchBar';
+import type { Apartment } from '../store/useAppStore';
+import type { SearchFilters } from '../store/useAppStore';
 
 const ApartmentsPage = () => {
   const { filteredApartments, setSelectedApartment, setShowBookingModal, setSearchFilters } = useAppStore();
@@ -37,7 +39,7 @@ const ApartmentsPage = () => {
       return;
     }
     
-    const urlFilters: any = { ...baseFilters };
+    const urlFilters: Partial<SearchFilters> = { ...baseFilters };
     
     // Handle rooms filter
     const roomsParam = searchParams.get('rooms');
@@ -81,7 +83,7 @@ const ApartmentsPage = () => {
     setSearchFilters(urlFilters);
   }, [searchParams, setSearchFilters]);
 
-  const handleBookingClick = (apartment: any) => {
+  const handleBookingClick = (apartment: Apartment) => {
     setSelectedApartment(apartment);
     setShowBookingModal(true);
   };

--- a/src/pages/ComplexPage.tsx
+++ b/src/pages/ComplexPage.tsx
@@ -59,6 +59,15 @@ const ComplexPage = () => {
     setCurrentImageIndex((prev) => (prev - 1 + images.length) % images.length);
   };
 
+  useEffect(() => {
+    if (images.length > 1) {
+      const interval = setInterval(() => {
+        setCurrentImageIndex(prev => (prev + 1) % images.length);
+      }, 4000);
+      return () => clearInterval(interval);
+    }
+  }, [images]);
+
   return (
     <div className="min-h-screen pt-20">
       {/* Breadcrumbs */}
@@ -365,11 +374,11 @@ const ComplexPage = () => {
                     <h3 className="text-xl font-semibold text-gray-900 mb-6">
                       Удобства и инфраструктура
                     </h3>
-                    <div className="space-y-3">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 justify-items-center">
                       {complex.amenities.map((amenity, index) => (
                         <div
                           key={index}
-                          className="flex items-center justify-center text-gray-600"
+                          className="flex items-center text-gray-600"
                         >
                           <svg
                             className="w-5 h-5 text-green-500 mr-3 flex-shrink-0"

--- a/src/pages/ComplexPage.tsx
+++ b/src/pages/ComplexPage.tsx
@@ -61,15 +61,6 @@ const ComplexPage = () => {
     setCurrentImageIndex((prev) => (prev - 1 + images.length) % images.length);
   };
 
-  useEffect(() => {
-    if (images.length > 1) {
-      const interval = setInterval(() => {
-        setCurrentImageIndex(prev => (prev + 1) % images.length);
-      }, 4000);
-      return () => clearInterval(interval);
-    }
-  }, [images]);
-
   return (
     <div className="min-h-screen pt-20">
       {/* Breadcrumbs */}

--- a/src/pages/ComplexPage.tsx
+++ b/src/pages/ComplexPage.tsx
@@ -268,62 +268,25 @@ const ComplexPage = () => {
             )}
             {/* Construction History */}
             {complex.constructionHistory && (
-              <div className="mb-16 w-full bg-white shadow-lg">
-                <div className="flex flex-col md:flex-row items-stretch gap-0 w-full">
-                  {/* Text block - 60% */}
-                  <div className="md:w-3/5 w-full p-8 flex flex-col justify-center">
-                    <h3 className="text-2xl font-semibold text-gray-900 mb-8 text-center md:text-left">История строительства</h3>
-                    <div className="text-gray-700 text-lg">
-                      {`Строительство: ${new Date(complex.constructionHistory.startDate).toLocaleDateString('ru-RU')} - ${new Date(complex.constructionHistory.endDate).toLocaleDateString('ru-RU')}. `}
-                      {complex.constructionHistory.phases.map(phase => phase.description).join(' ')}
-                    </div>
+              <div className="mb-16">
+                <h3 className="text-2xl font-semibold text-gray-900 mb-8 text-center">История строительства</h3>
+                <div className="bg-white rounded-xl p-8 shadow-lg">
+                  <div className="text-center mb-8">
+                    <p className="text-gray-600">Строительство: {new Date(complex.constructionHistory.startDate).toLocaleDateString('ru-RU')} - {new Date(complex.constructionHistory.endDate).toLocaleDateString('ru-RU')}</p>
                   </div>
-                  {/* Photo slider - 40% */}
-                  <div className="md:w-2/5 w-full flex items-center justify-center p-8 relative min-h-[16rem] md:min-h-[20rem]">
-                    <AnimatePresence initial={false}>
-                      <motion.img
-                        key={currentImageIndex}
-                        src={complex.images && complex.images.length > 0 ? complex.images[currentImageIndex % complex.images.length] : '/images/test.png'}
-                        alt={`Фото строительства ${currentImageIndex + 1}`}
-                        className="w-full h-64 md:h-80 object-cover rounded-xl"
-                        initial={{ opacity: 0, x: 50 }}
-                        animate={{ opacity: 1, x: 0 }}
-                        exit={{ opacity: 0, x: -50 }}
-                        transition={{ duration: 0.5 }}
-                      />
-                    </AnimatePresence>
-                    {complex.images && complex.images.length > 1 && (
-                      <>
-                        <button
-                          onClick={prevImage}
-                          className="absolute left-2 top-1/2 transform -translate-y-1/2 bg-black bg-opacity-50 text-white p-2 rounded-full hover:bg-opacity-70 z-10"
-                        >
-                          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-                          </svg>
-                        </button>
-                        <button
-                          onClick={nextImage}
-                          className="absolute right-2 top-1/2 transform -translate-y-1/2 bg-black bg-opacity-50 text-white p-2 rounded-full hover:bg-opacity-70 z-10"
-                        >
-                          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                          </svg>
-                        </button>
-                      </>
-                    )}
-                    {/* Dots */}
-                    {complex.images && complex.images.length > 1 && (
-                      <div className="absolute bottom-2 left-1/2 transform -translate-x-1/2 flex space-x-2 z-10">
-                        {complex.images.map((_, idx) => (
-                          <button
-                            key={idx}
-                            onClick={() => setCurrentImageIndex(idx)}
-                            className={`w-2 h-2 rounded-full ${idx === currentImageIndex ? 'bg-blue-600' : 'bg-gray-300'} transition-all`}
-                          />
-                        ))}
+                  <div className="space-y-6">
+                    {complex.constructionHistory.phases.map((phase, index) => (
+                      <div key={index} className="flex items-start">
+                        <div className="flex-shrink-0 w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-semibold mr-4">{index + 1}</div>
+                        <div className="flex-grow">
+                          <div className="flex items-center justify-between mb-2">
+                            <h4 className="font-semibold text-gray-900">{phase.name}</h4>
+                            <span className="text-sm text-gray-500">{new Date(phase.date).toLocaleDateString('ru-RU')}</span>
+                          </div>
+                          <p className="text-gray-600">{phase.description}</p>
+                        </div>
                       </div>
-                    )}
+                    ))}
                   </div>
                 </div>
               </div>

--- a/src/pages/ComplexPage.tsx
+++ b/src/pages/ComplexPage.tsx
@@ -2,6 +2,7 @@ import {useEffect, useState} from 'react';
 import {useParams, Link} from 'react-router-dom';
 import {useAppStore} from '../store/useAppStore';
 import ApartmentCard from '../components/ApartmentCard';
+import { motion, AnimatePresence } from 'framer-motion';
 
 const ComplexPage = () => {
   const {complexName} = useParams<{ complexName: string }>();
@@ -89,15 +90,23 @@ const ComplexPage = () => {
       {/* Photo Slider */}
       <section className="relative h-96 md:h-[500px]">
         <div className="relative h-full overflow-hidden bg-gray-200">
-          <img
-            src={images[currentImageIndex]}
-            alt={`${complex.name} - фото ${currentImageIndex + 1}`}
-            className="w-full h-full object-cover"
-            onError={(e) => {
-              const target = e.target as HTMLImageElement;
-              target.src = '/images/test.png';
-            }}
-          />
+          <AnimatePresence initial={false} custom={currentImageIndex}>
+            <motion.img
+              key={currentImageIndex}
+              src={images[currentImageIndex]}
+              alt={`${complex.name} - фото ${currentImageIndex + 1}`}
+              className="w-full h-full object-cover absolute inset-0"
+              onError={(e) => {
+                const target = e.target as HTMLImageElement;
+                target.src = '/images/test.png';
+              }}
+              initial={{ opacity: 0, x: 50 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -50 }}
+              transition={{ duration: 0.5 }}
+              style={{ position: 'absolute' }}
+            />
+          </AnimatePresence>
 
           {/* Navigation Arrows */}
           {images.length > 1 && (
@@ -186,406 +195,210 @@ const ComplexPage = () => {
         )}
       </section>
 
-      {/* Navigation Tabs */}
-      <section className="bg-white shadow-sm">
+      {/* Apartments Preview */}
+      <section className="py-12">
         <div className="container mx-auto px-4">
-          <nav className="flex space-x-8">
-            <button
-              onClick={() => setActiveTab('apartments')}
-              className={`py-4 px-2 border-b-2 font-medium text-sm transition-colors ${
-                activeTab === 'apartments'
-                  ? 'border-blue-500 text-blue-600'
-                  : 'border-transparent text-gray-500 hover:text-gray-700'
-              }`}
-            >
-              Квартиры ({complex.apartments.length})
-            </button>
-            <button
-              onClick={() => setActiveTab('about')}
-              className={`py-4 px-2 border-b-2 font-medium text-sm transition-colors ${
-                activeTab === 'about'
-                  ? 'border-blue-500 text-blue-600'
-                  : 'border-transparent text-gray-500 hover:text-gray-700'
-              }`}
-            >
-              О комплексе
-            </button>
-            <button
-              onClick={() => setActiveTab('location')}
-              className={`py-4 px-2 border-b-2 font-medium text-sm transition-colors ${
-                activeTab === 'location'
-                  ? 'border-blue-500 text-blue-600'
-                  : 'border-transparent text-gray-500 hover:text-gray-700'
-              }`}
-            >
-              Расположение
-            </button>
-          </nav>
+          <div className="flex items-center justify-between mb-8">
+            <h2 className="text-2xl font-bold text-gray-900">Доступные квартиры</h2>
+            {complex.apartments.length > 4 && (
+              <Link
+                to={`/apartments?complex=${encodeURIComponent(complex.name)}`}
+                className="bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition-colors"
+              >
+                Показать все квартиры
+              </Link>
+            )}
+          </div>
+          {complex.apartments.length > 0 ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+              {complex.apartments.slice(0, 4).map(apartment => (
+                <ApartmentCard
+                  key={apartment.id}
+                  apartment={apartment}
+                  onBookingClick={() => handleBookingClick(apartment)}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="text-center py-12">
+              <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                <svg className="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+                </svg>
+              </div>
+              <h3 className="text-lg font-medium text-gray-900 mb-2">Квартиры временно недоступны</h3>
+              <p className="text-gray-600 mb-6">В данный момент в этом комплексе нет доступных квартир. Оставьте заявку, и мы уведомим вас о новых предложениях.</p>
+              <button
+                onClick={() => handleBookingClick()}
+                className="bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition-colors"
+              >
+                Оставить заявку
+              </button>
+            </div>
+          )}
         </div>
       </section>
 
-      {/* Content */}
-      <section className="py-12">
+      {/* About/Description, Features, History, Amenities, etc. */}
+      <section className="py-12 bg-white">
         <div className="container mx-auto px-4">
-          {/* Apartments Tab */}
-          {activeTab === 'apartments' && (
-            <div>
-              <div className="flex items-center justify-between mb-8">
-                <h2 className="text-2xl font-bold text-gray-900">
-                  Доступные квартиры
-                </h2>
-                <div className="text-sm text-gray-600">
-                  Найдено: {complex.apartments.length} квартир
-                </div>
-              </div>
-
-              {complex.apartments.length > 0 ? (
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-                  {complex.apartments.map(apartment => (
-                    <ApartmentCard
-                      key={apartment.id}
-                      apartment={apartment}
-                      onBookingClick={() => handleBookingClick(apartment)}
-                    />
+          <div className="max-w-6xl mx-auto">
+            <h2 className="text-3xl font-bold text-gray-900 mb-12 text-center">О жилом комплексе</h2>
+            {/* Description */}
+            <div className="text-center mb-16">
+              <p className="text-lg text-gray-600 leading-relaxed max-w-4xl mx-auto">{complex.description}</p>
+            </div>
+            {/* Features of LCD */}
+            {complex.features && complex.features.length > 0 && (
+              <div className="mb-16">
+                <h3 className="text-2xl font-semibold text-gray-900 mb-8 text-center">Особенности ЖК</h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                  {complex.features.map((feature, index) => (
+                    <div key={index} className="bg-white rounded-xl p-6 shadow-lg text-center">
+                      <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                        <svg className="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                        </svg>
+                      </div>
+                      <p className="text-gray-700 font-medium">{feature}</p>
+                    </div>
                   ))}
                 </div>
-              ) : (
-                <div className="text-center py-12">
-                  <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                    <svg
-                      className="w-8 h-8 text-gray-400"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
-                      />
-                    </svg>
-                  </div>
-                  <h3 className="text-lg font-medium text-gray-900 mb-2">
-                    Квартиры временно недоступны
-                  </h3>
-                  <p className="text-gray-600 mb-6">
-                    В данный момент в этом комплексе нет доступных квартир.
-                    Оставьте заявку, и мы уведомим вас о новых предложениях.
-                  </p>
-                  <button
-                    onClick={() => handleBookingClick()}
-                    className="bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition-colors"
-                  >
-                    Оставить заявку
-                  </button>
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* About Tab */}
-          {activeTab === 'about' && (
-            <div className="max-w-6xl mx-auto">
-              <h2 className="text-3xl font-bold text-gray-900 mb-12 text-center">
-                О жилом комплексе
-              </h2>
-
-              {/* Description */}
-              <div className="text-center mb-16">
-                <p className="text-lg text-gray-600 leading-relaxed max-w-4xl mx-auto">
-                  {complex.description}
-                </p>
               </div>
-
-              {/* Features of LCD */}
-              {complex.features && complex.features.length > 0 && (
-                <div className="mb-16">
-                  <h3 className="text-2xl font-semibold text-gray-900 mb-8 text-center">
-                    Особенности ЖК
-                  </h3>
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                    {complex.features.map((feature, index) => (
-                      <div
-                        key={index}
-                        className="bg-white rounded-xl p-6 shadow-lg text-center"
-                      >
-                        <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                          <svg
-                            className="w-6 h-6 text-blue-600"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={2}
-                              d="M5 13l4 4L19 7"
-                            />
-                          </svg>
+            )}
+            {/* Construction History */}
+            {complex.constructionHistory && (
+              <div className="mb-16">
+                <h3 className="text-2xl font-semibold text-gray-900 mb-8 text-center">История строительства</h3>
+                <div className="bg-white rounded-xl p-8 shadow-lg">
+                  <div className="text-center mb-8">
+                    <p className="text-gray-600">Строительство: {new Date(complex.constructionHistory.startDate).toLocaleDateString('ru-RU')} - {new Date(complex.constructionHistory.endDate).toLocaleDateString('ru-RU')}</p>
+                  </div>
+                  <div className="space-y-6">
+                    {complex.constructionHistory.phases.map((phase, index) => (
+                      <div key={index} className="flex items-start">
+                        <div className="flex-shrink-0 w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-semibold mr-4">{index + 1}</div>
+                        <div className="flex-grow">
+                          <div className="flex items-center justify-between mb-2">
+                            <h4 className="font-semibold text-gray-900">{phase.name}</h4>
+                            <span className="text-sm text-gray-500">{new Date(phase.date).toLocaleDateString('ru-RU')}</span>
+                          </div>
+                          <p className="text-gray-600">{phase.description}</p>
                         </div>
-                        <p className="text-gray-700 font-medium">{feature}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+            {/* Amenities and Key Characteristics */}
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
+              {complex.amenities && complex.amenities.length > 0 && (
+                <div className="text-center">
+                  <h3 className="text-xl font-semibold text-gray-900 mb-6">Удобства и инфраструктура</h3>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 justify-items-center">
+                    {complex.amenities.map((amenity, index) => (
+                      <div key={index} className="flex items-center text-gray-600">
+                        <svg className="w-5 h-5 text-green-500 mr-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                        </svg>
+                        {amenity}
                       </div>
                     ))}
                   </div>
                 </div>
               )}
-
-              {/* Construction History */}
-              {complex.constructionHistory && (
-                <div className="mb-16">
-                  <h3 className="text-2xl font-semibold text-gray-900 mb-8 text-center">
-                    История строительства
-                  </h3>
-                  <div className="bg-white rounded-xl p-8 shadow-lg">
-                    <div className="text-center mb-8">
-                      <p className="text-gray-600">
-                        Строительство: {new Date(complex.constructionHistory.startDate).toLocaleDateString('ru-RU')} - {new Date(complex.constructionHistory.endDate).toLocaleDateString('ru-RU')}
-                      </p>
-                    </div>
-                    <div className="space-y-6">
-                      {complex.constructionHistory.phases.map((phase, index) => (
-                        <div
-                          key={index}
-                          className="flex items-start"
-                        >
-                          <div className="flex-shrink-0 w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-semibold mr-4">
-                            {index + 1}
-                          </div>
-                          <div className="flex-grow">
-                            <div className="flex items-center justify-between mb-2">
-                              <h4 className="font-semibold text-gray-900">{phase.name}</h4>
-                              <span className="text-sm text-gray-500">{new Date(phase.date).toLocaleDateString('ru-RU')}</span>
-                            </div>
-                            <p className="text-gray-600">{phase.description}</p>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
+              <div className="text-center">
+                <h3 className="text-xl font-semibold text-gray-900 mb-6">Ключевые характеристики</h3>
+                <div className="space-y-4">
+                  <div className="flex justify-between py-2 border-b border-gray-200">
+                    <span className="text-gray-600">Всего квартир:</span>
+                    <span className="font-medium">{complex.apartments.length}</span>
                   </div>
-                </div>
-              )}
-
-              {/* Amenities and Key Characteristics */}
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
-                {complex.amenities && complex.amenities.length > 0 && (
-                  <div className="text-center">
-                    <h3 className="text-xl font-semibold text-gray-900 mb-6">
-                      Удобства и инфраструктура
-                    </h3>
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 justify-items-center">
-                      {complex.amenities.map((amenity, index) => (
-                        <div
-                          key={index}
-                          className="flex items-center text-gray-600"
-                        >
-                          <svg
-                            className="w-5 h-5 text-green-500 mr-3 flex-shrink-0"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={2}
-                              d="M5 13l4 4L19 7"
-                            />
-                          </svg>
-                          {amenity}
-                        </div>
-                      ))}
-                    </div>
+                  <div className="flex justify-between py-2 border-b border-gray-200">
+                    <span className="text-gray-600">Тип квартир:</span>
+                    <span className="font-medium">{Array.from(new Set(complex.apartments.map(apt => `${apt.rooms}-комн.`))).join(', ')}</span>
                   </div>
-                )}
-
-                <div className="text-center">
-                  <h3 className="text-xl font-semibold text-gray-900 mb-6">
-                    Ключевые характеристики
-                  </h3>
-                  <div className="space-y-4">
-                    <div className="flex justify-between py-2 border-b border-gray-200">
-                      <span className="text-gray-600">Всего квартир:</span>
-                      <span className="font-medium">{complex.apartments.length}</span>
-                    </div>
-                    <div className="flex justify-between py-2 border-b border-gray-200">
-                      <span className="text-gray-600">Тип квартир:</span>
-                      <span className="font-medium">
-                        {Array.from(new Set(complex.apartments.map(apt => `${apt.rooms}-комн.`))).join(', ')}
-                      </span>
-                    </div>
-                    <div className="flex justify-between py-2 border-b border-gray-200">
-                      <span className="text-gray-600">Отделка:</span>
-                      <span className="font-medium">
-                        {Array.from(new Set(complex.apartments.map(apt => apt.finishing))).join(', ')}
-                      </span>
-                    </div>
-                    <div className="flex justify-between py-2 border-b border-gray-200">
-                      <span className="text-gray-600">Адрес:</span>
-                      <span className="font-medium">{complex.address}</span>
-                    </div>
+                  <div className="flex justify-between py-2 border-b border-gray-200">
+                    <span className="text-gray-600">Отделка:</span>
+                    <span className="font-medium">{Array.from(new Set(complex.apartments.map(apt => apt.finishing))).join(', ')}</span>
+                  </div>
+                  <div className="flex justify-between py-2 border-b border-gray-200">
+                    <span className="text-gray-600">Адрес:</span>
+                    <span className="font-medium">{complex.address}</span>
                   </div>
                 </div>
               </div>
             </div>
-          )}
+          </div>
+        </div>
+      </section>
 
-          {/* Location Tab */}
-          {activeTab === 'location' && (
-            <div className="max-w-6xl mx-auto">
-              <h2 className="text-3xl font-bold text-gray-900 mb-12 text-center">
-                Расположение и транспорт
-              </h2>
-
-              <div className="bg-gray-100 rounded-xl p-8 text-center mb-8">
-                <div className="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                  <svg
-                    className="w-8 h-8 text-blue-600"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-                    />
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-                    />
-                  </svg>
-                </div>
-                <h3 className="text-lg font-semibold text-gray-900 mb-2">
-                  Интерактивная карта
-                </h3>
-                <p className="text-gray-600 mb-4">
-                  Здесь будет отображена карта с расположением жилого комплекса
-                </p>
-                <p className="text-sm text-gray-500">
-                  📍 {complex.address}
-                </p>
+      {/* Location Section */}
+      <section className="py-12">
+        <div className="container mx-auto px-4">
+          <div className="max-w-6xl mx-auto">
+            <h2 className="text-3xl font-bold text-gray-900 mb-12 text-center">Расположение и транспорт</h2>
+            <div className="bg-gray-100 rounded-xl p-8 text-center mb-8">
+              <div className="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                <svg className="w-8 h-8 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
               </div>
-
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                <div>
-                  <h3 className="text-lg font-semibold text-gray-900 mb-4">
-                    Транспортная доступность
-                  </h3>
-                  <ul className="space-y-3 text-gray-600">
-                    <li className="flex items-center">
-                      <svg
-                        className="w-5 h-5 text-blue-600 mr-3"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"
-                        />
-                      </svg>
-                      Метро "Примерная" - 5 мин пешком
-                    </li>
-                    <li className="flex items-center">
-                      <svg
-                        className="w-5 h-5 text-green-600 mr-3"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                        />
-                      </svg>
-                      Автобусная остановка - 2 мин пешком
-                    </li>
-                    <li className="flex items-center">
-                      <svg
-                        className="w-5 h-5 text-purple-600 mr-3"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"
-                        />
-                      </svg>
-                      До центра города - 15 мин на транспорте
-                    </li>
-                  </ul>
-                </div>
-
-                <div>
-                  <h3 className="text-lg font-semibold text-gray-900 mb-4">
-                    Инфраструктура района
-                  </h3>
-                  <ul className="space-y-3 text-gray-600">
-                    <li className="flex items-center">
-                      <svg
-                        className="w-5 h-5 text-red-600 mr-3"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-                        />
-                      </svg>
-                      Школы и детские сады поблизости
-                    </li>
-                    <li className="flex items-center">
-                      <svg
-                        className="w-5 h-5 text-green-600 mr-3"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z"
-                        />
-                      </svg>
-                      Торговые центры и магазины
-                    </li>
-                    <li className="flex items-center">
-                      <svg
-                        className="w-5 h-5 text-blue-600 mr-3"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
-                        />
-                      </svg>
-                      Медицинские учреждения
-                    </li>
-                  </ul>
-                </div>
+              <h3 className="text-lg font-semibold text-gray-900 mb-2">Интерактивная карта</h3>
+              <p className="text-gray-600 mb-4">Здесь будет отображена карта с расположением жилого комплекса</p>
+              <p className="text-sm text-gray-500">📍 {complex.address}</p>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900 mb-4">Транспортная доступность</h3>
+                <ul className="space-y-3 text-gray-600">
+                  <li className="flex items-center">
+                    <svg className="w-5 h-5 text-blue-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+                    </svg>
+                    Метро "Примерная" - 5 мин пешком
+                  </li>
+                  <li className="flex items-center">
+                    <svg className="w-5 h-5 text-green-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                    Автобусная остановка - 2 мин пешком
+                  </li>
+                  <li className="flex items-center">
+                    <svg className="w-5 h-5 text-purple-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" />
+                    </svg>
+                    До центра города - 15 мин на транспорте
+                  </li>
+                </ul>
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900 mb-4">Инфраструктура района</h3>
+                <ul className="space-y-3 text-gray-600">
+                  <li className="flex items-center">
+                    <svg className="w-5 h-5 text-red-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+                    </svg>
+                    Школы и детские сады поблизости
+                  </li>
+                  <li className="flex items-center">
+                    <svg className="w-5 h-5 text-green-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
+                    </svg>
+                    Торговые центры и магазины
+                  </li>
+                  <li className="flex items-center">
+                    <svg className="w-5 h-5 text-yellow-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 1.343-3 3s1.343 3 3 3 3-1.343 3-3-1.343-3-3-3zm0 0V4m0 8v8" />
+                    </svg>
+                    Парки и зоны отдыха
+                  </li>
+                </ul>
               </div>
             </div>
-          )}
+          </div>
         </div>
       </section>
 

--- a/src/pages/ComplexPage.tsx
+++ b/src/pages/ComplexPage.tsx
@@ -268,22 +268,28 @@ const ComplexPage = () => {
             )}
             {/* Construction History */}
             {complex.constructionHistory && (
-              <div className="mb-16">
-                <h3 className="text-2xl font-semibold text-gray-900 mb-8 text-center">История строительства</h3>
-                <div className="bg-white rounded-xl p-8 shadow-lg flex flex-col md:flex-row gap-8 items-center">
-                  {/* Photo slider */}
-                  <div className="relative w-full md:w-1/2 h-64 md:h-80 flex-shrink-0">
+              <div className="mb-16 w-full bg-white shadow-lg">
+                <div className="max-w-full flex flex-col md:flex-row items-stretch gap-0">
+                  {/* Text block - 60% */}
+                  <div className="md:w-3/5 w-full p-8 flex flex-col justify-center">
+                    <h3 className="text-2xl font-semibold text-gray-900 mb-8 text-center md:text-left">История строительства</h3>
+                    <div className="text-gray-700 text-lg">
+                      {`Строительство: ${new Date(complex.constructionHistory.startDate).toLocaleDateString('ru-RU')} - ${new Date(complex.constructionHistory.endDate).toLocaleDateString('ru-RU')}. `}
+                      {complex.constructionHistory.phases.map(phase => phase.description).join(' ')}
+                    </div>
+                  </div>
+                  {/* Photo slider - 40% */}
+                  <div className="md:w-2/5 w-full flex items-center justify-center p-8 relative min-h-[16rem] md:min-h-[20rem]">
                     <AnimatePresence initial={false}>
                       <motion.img
                         key={currentImageIndex}
                         src={complex.images && complex.images.length > 0 ? complex.images[currentImageIndex % complex.images.length] : '/images/test.png'}
                         alt={`Фото строительства ${currentImageIndex + 1}`}
-                        className="w-full h-full object-cover rounded-xl absolute inset-0"
+                        className="w-full h-64 md:h-80 object-cover rounded-xl"
                         initial={{ opacity: 0, x: 50 }}
                         animate={{ opacity: 1, x: 0 }}
                         exit={{ opacity: 0, x: -50 }}
                         transition={{ duration: 0.5 }}
-                        style={{ position: 'absolute' }}
                       />
                     </AnimatePresence>
                     {complex.images && complex.images.length > 1 && (
@@ -318,11 +324,6 @@ const ComplexPage = () => {
                         ))}
                       </div>
                     )}
-                  </div>
-                  {/* Solid text block */}
-                  <div className="w-full md:w-1/2 text-gray-700 text-lg">
-                    {`Строительство: ${new Date(complex.constructionHistory.startDate).toLocaleDateString('ru-RU')} - ${new Date(complex.constructionHistory.endDate).toLocaleDateString('ru-RU')}. `}
-                    {complex.constructionHistory.phases.map(phase => phase.description).join(' ')}
                   </div>
                 </div>
               </div>

--- a/src/pages/ComplexPage.tsx
+++ b/src/pages/ComplexPage.tsx
@@ -269,7 +269,7 @@ const ComplexPage = () => {
             {/* Construction History */}
             {complex.constructionHistory && (
               <div className="mb-16 w-full bg-white shadow-lg">
-                <div className="max-w-full flex flex-col md:flex-row items-stretch gap-0">
+                <div className="flex flex-col md:flex-row items-stretch gap-0 w-full">
                   {/* Text block - 60% */}
                   <div className="md:w-3/5 w-full p-8 flex flex-col justify-center">
                     <h3 className="text-2xl font-semibold text-gray-900 mb-8 text-center md:text-left">История строительства</h3>

--- a/src/pages/ComplexPage.tsx
+++ b/src/pages/ComplexPage.tsx
@@ -270,23 +270,59 @@ const ComplexPage = () => {
             {complex.constructionHistory && (
               <div className="mb-16">
                 <h3 className="text-2xl font-semibold text-gray-900 mb-8 text-center">История строительства</h3>
-                <div className="bg-white rounded-xl p-8 shadow-lg">
-                  <div className="text-center mb-8">
-                    <p className="text-gray-600">Строительство: {new Date(complex.constructionHistory.startDate).toLocaleDateString('ru-RU')} - {new Date(complex.constructionHistory.endDate).toLocaleDateString('ru-RU')}</p>
-                  </div>
-                  <div className="space-y-6">
-                    {complex.constructionHistory.phases.map((phase, index) => (
-                      <div key={index} className="flex items-start">
-                        <div className="flex-shrink-0 w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-semibold mr-4">{index + 1}</div>
-                        <div className="flex-grow">
-                          <div className="flex items-center justify-between mb-2">
-                            <h4 className="font-semibold text-gray-900">{phase.name}</h4>
-                            <span className="text-sm text-gray-500">{new Date(phase.date).toLocaleDateString('ru-RU')}</span>
-                          </div>
-                          <p className="text-gray-600">{phase.description}</p>
-                        </div>
+                <div className="bg-white rounded-xl p-8 shadow-lg flex flex-col md:flex-row gap-8 items-center">
+                  {/* Photo slider */}
+                  <div className="relative w-full md:w-1/2 h-64 md:h-80 flex-shrink-0">
+                    <AnimatePresence initial={false}>
+                      <motion.img
+                        key={currentImageIndex}
+                        src={complex.images && complex.images.length > 0 ? complex.images[currentImageIndex % complex.images.length] : '/images/test.png'}
+                        alt={`Фото строительства ${currentImageIndex + 1}`}
+                        className="w-full h-full object-cover rounded-xl absolute inset-0"
+                        initial={{ opacity: 0, x: 50 }}
+                        animate={{ opacity: 1, x: 0 }}
+                        exit={{ opacity: 0, x: -50 }}
+                        transition={{ duration: 0.5 }}
+                        style={{ position: 'absolute' }}
+                      />
+                    </AnimatePresence>
+                    {complex.images && complex.images.length > 1 && (
+                      <>
+                        <button
+                          onClick={prevImage}
+                          className="absolute left-2 top-1/2 transform -translate-y-1/2 bg-black bg-opacity-50 text-white p-2 rounded-full hover:bg-opacity-70 z-10"
+                        >
+                          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                          </svg>
+                        </button>
+                        <button
+                          onClick={nextImage}
+                          className="absolute right-2 top-1/2 transform -translate-y-1/2 bg-black bg-opacity-50 text-white p-2 rounded-full hover:bg-opacity-70 z-10"
+                        >
+                          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                          </svg>
+                        </button>
+                      </>
+                    )}
+                    {/* Dots */}
+                    {complex.images && complex.images.length > 1 && (
+                      <div className="absolute bottom-2 left-1/2 transform -translate-x-1/2 flex space-x-2 z-10">
+                        {complex.images.map((_, idx) => (
+                          <button
+                            key={idx}
+                            onClick={() => setCurrentImageIndex(idx)}
+                            className={`w-2 h-2 rounded-full ${idx === currentImageIndex ? 'bg-blue-600' : 'bg-gray-300'} transition-all`}
+                          />
+                        ))}
                       </div>
-                    ))}
+                    )}
+                  </div>
+                  {/* Solid text block */}
+                  <div className="w-full md:w-1/2 text-gray-700 text-lg">
+                    {`Строительство: ${new Date(complex.constructionHistory.startDate).toLocaleDateString('ru-RU')} - ${new Date(complex.constructionHistory.endDate).toLocaleDateString('ru-RU')}. `}
+                    {complex.constructionHistory.phases.map(phase => phase.description).join(' ')}
                   </div>
                 </div>
               </div>

--- a/src/pages/ComplexPage.tsx
+++ b/src/pages/ComplexPage.tsx
@@ -3,6 +3,7 @@ import {useParams, Link} from 'react-router-dom';
 import {useAppStore} from '../store/useAppStore';
 import ApartmentCard from '../components/ApartmentCard';
 import { motion, AnimatePresence } from 'framer-motion';
+import type { Apartment } from '../store/useAppStore';
 
 const ComplexPage = () => {
   const {complexName} = useParams<{ complexName: string }>();
@@ -43,7 +44,7 @@ const ComplexPage = () => {
     );
   }
 
-  const handleBookingClick = (apartment?: any) => {
+  const handleBookingClick = (apartment?: Apartment) => {
     if (apartment) {
       setSelectedApartment(apartment);
     }

--- a/src/pages/ComplexesPage.tsx
+++ b/src/pages/ComplexesPage.tsx
@@ -46,7 +46,7 @@ const ComplexesPage = () => {
                 placeholder="Поиск по названию, адресу или описанию..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="w-full px-6 py-4 text-lg border border-gray-300 rounded-2xl focus:ring-2 focus:ring-blue-500 focus:border-transparent pl-14"
+                className="w-full px-6 py-4 text-lg border border-gray-300 rounded-2xl focus:ring-2 focus:ring-blue-500 focus:border-transparent pl-14 bg-white"
               />
               <svg
                 className="w-6 h-6 text-gray-400 absolute left-4 top-1/2 transform -translate-y-1/2"

--- a/src/pages/ComplexesPage.tsx
+++ b/src/pages/ComplexesPage.tsx
@@ -38,36 +38,35 @@ const ComplexesPage = () => {
               Выберите идеальный жилой комплекс из нашего широкого портфолио современных проектов
             </p>
           </div>
+          {/* Search Section - moved here */}
+          <div className="max-w-2xl mx-auto mt-8">
+            <div className="relative">
+              <input
+                type="text"
+                placeholder="Поиск по названию, адресу или описанию..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="w-full px-6 py-4 text-lg border border-gray-300 rounded-2xl focus:ring-2 focus:ring-blue-500 focus:border-transparent pl-14"
+              />
+              <svg
+                className="w-6 h-6 text-gray-400 absolute left-4 top-1/2 transform -translate-y-1/2"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
+              </svg>
+            </div>
+          </div>
         </div>
       </section>
 
       <div className="container mx-auto px-4 py-12">
-        {/* Search Section */}
-        <div className="max-w-2xl mx-auto mb-12">
-          <div className="relative">
-            <input
-              type="text"
-              placeholder="Поиск по названию, адресу или описанию..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full px-6 py-4 text-lg border border-gray-300 rounded-2xl focus:ring-2 focus:ring-blue-500 focus:border-transparent pl-14"
-            />
-            <svg
-              className="w-6 h-6 text-gray-400 absolute left-4 top-1/2 transform -translate-y-1/2"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-              />
-            </svg>
-          </div>
-        </div>
-
         {/* Results Count */}
         <div className="mb-8">
           <p className="text-gray-600">


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable clicking on apartment cards to navigate to their detail page and add a location section to the apartment page, mirroring LCD functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-5061f99f-2948-42a4-9199-ef874a5abfb7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5061f99f-2948-42a4-9199-ef874a5abfb7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>